### PR TITLE
Added option for enabling local users

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ composer require benjaminmedia/wp-wa-oauth
 Download lastest release from: https://github.com/BenjaminMedia/wp-wa-oauth/releases
 And unzip and place in your /wp-content/plugins directory.
 
+#### Getting credentials and Configuration
+
 Once you have installed and activated the plugin then make sure that you have a set of api credentials.
 If you do not have a set of credentials then you should contact Bonnier to get them.
 You need to have a set of credentials for each domain on your site.
@@ -47,6 +49,66 @@ Then you may visit the the edit page for each page/post and here you will find a
 box called: 'WA OAuth locked content'. Any setting you make here will override
 the Global settings you have set.
 
+#### Creating local users
+
+As of version 1.1.0 and up the plugin now supports creating local users.
+This means that you from the plugin settings page can toggle wether you
+want the plugin to create WordPress users after they have logged in.
+
+If you enable this feature you may also choose an option wether the WordPress
+user should be automatically logged in to WordPress upon authenticating with WA.
+
+Users will be given custom roles created from the roles that WA delivers: currently
+this amounts to two roles ```users``` and ```subscribers```. To avoid conflicts
+with existing WordPress roles the role names will be prefixed with ```bp_wa_```
+meaning the final role names will be ```bp_wa_users``` and ```bp_wa_subscribers```.
+
+Both roles will be given only the read access this, will allow users to edit/view their profile and nothing in WordPress and nothing else.
+
+###### Customizing role capabilities:
+You may override the default capabilities of the roles created you should add
+the following filters to a plugin or your functions.php file.
+
+``` php
+// To override the default capabilities you should implement a filter like so
+
+add_filter('bp_wa_users_capabilities', function($defualt) {
+	return array_merge($default, ['edit_posts' => false]);
+});
+
+// you can either extend the default capabilities by doing an array merge or,
+// you can override the capabilities completely by returning a new array like so
+
+add_filter('bp_wa_subscribers_capabilities', function($defualt) {
+	return ['edit_posts' => true];
+});
+
+// note the filter follows a [role_name].[_capabilities] format
+
+```
+
+#### User update callbacks
+
+If you have the create local users option enabled, then what might happen is
+that the user will update their profile on the Main WhiteAlbum site. This,
+could potentially mean that the local user info that your have in your application
+can come out of sync. In order to counter this, WhiteAlbum has a callback feature,
+which means they can call your application each time there is a change to a user
+that has been logged in to your application.
+
+The Plugin automatically setups the callback route and will also handle the update
+of the user information itself, but before WhiteAlbum can call your app.
+They need to be informed of your callback url. The callback uri is generated from the following format:
+http://|https://[your-domain].[your-country]/wp-json/bp-wa-oauth/v1/oauth/callback
+
+Example url: http://test.komputer.dk/wp-json/bp-wa-oauth/v1/oauth/callback
+
+Your should give this url to Bonnier when requesting the credentials, then we
+will setup the callbacks.
+
+Note: the callback can only work so long as your user has been logged into the application for the last 24 hours. Otherwise the local user information,
+will not get updated, until the next time they login to your application.
+
 ### Usage Example:
 
 The following code snippet shows an Example in php that may be used in your theme template files.
@@ -67,9 +129,18 @@ The following code snippet shows an Example in php that may be used in your them
 	<!-- 	
 		If we are authenticated;
 		then we can get the current user info by calling: get_user()
+		get_user() returns either a WP_User object or a stdClass if the create
+		local user option is disabled.
 	-->
 
 		<?php echo bp_wa_oauth()->get_user()->first_name; ?>
+
+		<!-- 	
+			You can add logout buttons to trigger a logout, note this will not destroy
+			your WhiteAlbum session. It will only log you out of the current site.
+		-->
+		<button class="bp-wa-oauth-logout">login and return here</button>
+		<button class="bp-wa-oauth-logout" data-bp-wa-oauth-redirect="/some/url" >login and redirect to specific url</button>
 
 		<!-- 	
 			If we are not authenticated;

--- a/js/bp-wa-oauth-login.js
+++ b/js/bp-wa-oauth-login.js
@@ -1,23 +1,43 @@
-function bp_wa_oauth_trigger_login(authDestination) {
+function bp_wa_oauth_trigger_login(redirectOnComplete) {
 
-    var loginUri = '/wp-json/bp-wa-oauth/v1/oauth/login';
+    const loginUri = '/wp-json/bp-wa-oauth/v1/oauth/login';
 
-    if (typeof authDestination === 'undefined') {
-        authDestination = document.location.href;
+    if (typeof redirectOnComplete === 'undefined') {
+        redirectOnComplete = document.location.href;
     }
 
-    window.location = loginUri + '?redirectUri=' + encodeURIComponent(authDestination);
+    window.location = loginUri + '?redirectUri=' + encodeURIComponent(redirectOnComplete);
+}
+
+function bp_wa_oauth_trigger_logout(redirectOnComplete) {
+
+    const loginUri = '/wp-json/bp-wa-oauth/v1/oauth/logout';
+
+    if (typeof redirectOnComplete === 'undefined') {
+        redirectOnComplete = document.location.href;
+    }
+
+    window.location = loginUri + '?redirectUri=' + encodeURIComponent(redirectOnComplete);
 }
 
 window.addEventListener('click', function (event) {
 
-    var triggerClass = 'bp-wa-oauth-login';
+    var loginTriggerClass = 'bp-wa-oauth-login';
+    var logoutTriggerClass = 'bp-wa-oauth-logout';
 
-    if (event.target.className.indexOf(triggerClass) > -1) {
+    if (event.target.className.indexOf(loginTriggerClass) > -1) {
         if (typeof event.target.dataset.bpWaOauthRedirect !== 'undefined') {
             bp_wa_oauth_trigger_login(event.target.dataset.bpWaOauthRedirect);
         } else {
             bp_wa_oauth_trigger_login();
+        }
+    }
+
+    if (event.target.className.indexOf(logoutTriggerClass) > -1) {
+        if (typeof event.target.dataset.bpWaOauthRedirect !== 'undefined') {
+            bp_wa_oauth_trigger_logout(event.target.dataset.bpWaOauthRedirect);
+        } else {
+            bp_wa_oauth_trigger_logout();
         }
     }
 });

--- a/src/Bonnier/WP/WaOauth/Http/Routes/UserUpdateCallbackRoute.php
+++ b/src/Bonnier/WP/WaOauth/Http/Routes/UserUpdateCallbackRoute.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Bonnier\WP\WaOauth\Http\Routes;
+
+use Bonnier\WP\WaOauth\Http\Exceptions\HttpException;
+use Bonnier\WP\WaOauth\Models\User;
+use Bonnier\WP\WaOauth\Services\ServiceOAuth;
+use Bonnier\WP\WaOauth\Settings\SettingsPage;
+use WP_REST_Request;
+use WP_REST_Response;
+
+class UserUpdateCallbackRoute
+{
+    const BASE_PREFIX = 'wp-json';
+
+    /**
+     * The namespace prefix.
+     */
+    const PLUGIN_PREFIX = 'bp-wa-oauth';
+
+    /**
+     * The namespace version.
+     */
+    const VERSION = 'v1';
+
+    /**
+     * The update user callback route
+     */
+    const USER_CALLBACK_ROUTE = '/oauth/callback';
+
+    /**
+     * The access token cookie lifetime.
+     */
+    const ACCESS_TOKEN_LIFETIME_HOURS = 24;
+
+    /* @var SettingsPage $settings */
+    private $settings;
+
+    /* @var ServiceOAuth $service */
+    private $service;
+
+    /**
+     * OauthLoginRoute constructor.
+     * @param SettingsPage $settings
+     */
+    public function __construct(SettingsPage $settings)
+    {
+        $this->settings = $settings;
+
+        add_action('rest_api_init', function () {
+            register_rest_route($this->get_route_namespace(), self::USER_CALLBACK_ROUTE, [
+                'methods' => 'POST',
+                'callback' => [$this, 'update_user_callback'],
+            ]);
+        });
+    }
+
+    /**
+     * The function that handles the user login request
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response
+     */
+    public function update_user_callback(WP_REST_Request $request)
+    {
+        $action = $request->get_param('action');
+        $waUserId = $request->get_param('payload');
+
+        if($action === 'user_updated' && $waUserId) {
+            $localUserId = User::get_local_user_id($waUserId);
+            $accessToken = User::get_access_token($localUserId);
+
+            if($accessToken && !empty($accessToken)) {
+                $this->update_user($localUserId, $accessToken);
+            }
+
+        }
+
+        return new WP_REST_Response('ok', 200);
+    }
+
+    private function update_user($localUserId, $accessToken) {
+
+        $service = $this->get_oauth_service();
+        $service->setAccessToken($accessToken);
+
+        try {
+            $updatedUser = $service->getUser();
+        } catch (HttpException $e) {
+            return false;
+        }
+
+        if($updatedUser) {
+
+            return User::update_local_user($localUserId, $updatedUser);
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the route namespace
+     *
+     * @return string
+     */
+    private function get_route_namespace()
+    {
+        return self::PLUGIN_PREFIX . DIRECTORY_SEPARATOR . self::VERSION;
+    }
+
+
+    /**
+     * Returns an instance of ServiceOauth
+     *
+     * @return ServiceOAuth
+     */
+    private function get_oauth_service()
+    {
+        if ($this->service) {
+            return $this->service;
+        }
+
+        $locale = $this->settings->get_current_locale();
+
+        return new ServiceOAuth(
+            $this->settings->get_api_user($locale),
+            $this->settings->get_api_secret($locale),
+            $this->settings->get_api_endpoint($locale)
+        );
+    }
+
+}

--- a/src/Bonnier/WP/WaOauth/Models/User.php
+++ b/src/Bonnier/WP/WaOauth/Models/User.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Bonnier\WP\WaOauth\Models;
+
+use Bonnier\WP\WaOauth\Settings\SettingsPage;
+use WP_User;
+
+class User
+{
+    const ACCESS_TOKEN_META_KEY = 'bp_wa_oauth_access_token';
+
+    public static function get_local_user_id($waId) {
+        global $wpdb;
+        return $wpdb->get_var(
+            $wpdb->prepare("SELECT user_id FROM wp_usermeta WHERE meta_key=%s AND meta_value=%d", 'wa_user_id', $waId)
+        );
+    }
+
+    public static function get_access_token($userId) {
+        return get_user_meta($userId, self::ACCESS_TOKEN_META_KEY, true);
+    }
+
+    public static function set_access_token($userId, $value) {
+        return update_user_meta($userId, self::ACCESS_TOKEN_META_KEY, $value);
+    }
+
+    public static function create_local_user($waUser, $accessToken) {
+
+        $localUser = new WP_User(self::get_local_user_id($waUser->id));
+
+        $localUser = self::set_user_props($localUser, $waUser);
+
+        $userId = wp_insert_user($localUser);
+
+        self::set_access_token($userId, $accessToken);
+
+        update_user_meta($userId, 'wa_user_id', $waUser->id);
+    }
+
+    public static function get_local_user($waUser) {
+        $localUser = new WP_User(self::get_local_user_id($waUser->id));
+        return $localUser ?: null;
+    }
+
+    public static function wp_login_user($user) {
+        if(isset($user->ID)) {
+            wp_set_current_user($user->ID, $user->user_login);
+            wp_set_auth_cookie($user->ID);
+            do_action( 'wp_login', $user->user_login );
+        }
+        return false;
+    }
+
+    public static function update_local_user($localUserId, $waUser)
+    {
+        $localUser = new WP_User($localUserId);
+
+        if($localUser->exists()) {
+
+            $localUser = self::set_user_props($localUser, $waUser);
+
+            $updated = wp_update_user($localUser);
+
+            return ! is_wp_error($updated);
+        }
+        return false;
+    }
+
+    private static function set_user_props($localUser, $waUser) {
+        $localUser->user_login = $waUser->username;
+        $localUser->first_name = $waUser->first_name;
+        $localUser->last_name = $waUser->last_name;
+        $localUser->user_url = $waUser->url;
+        $localUser->user_email = $waUser->email;
+
+        // Password is required when creating a new user
+        if(! $localUser->exists()) {
+            $localUser->user_pass = md5($waUser->username . time());
+        }
+
+        $localUser = self::set_user_roles($localUser, $waUser->roles);
+
+        return $localUser;
+    }
+
+    private static function set_user_roles($localUser, $roles)
+    {
+        foreach ($roles as $role) {
+            $localUser->set_role(SettingsPage::ROLES_PREFIX . $role);
+        }
+        return $localUser;
+    }
+}


### PR DESCRIPTION
- Creation of local users may now be enabled from the plugin settings
  page.
- Automatic login of local users may also be enabled from  the plugin
  settings page
- A logout route and btn trigger class has also been added
- Visiting the login route without a redirect param now takes you to
  the user profile page
